### PR TITLE
chore(action): update from Node16 to Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,5 +68,5 @@ inputs:
     default: "actions"
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
:rotating_light: Node16 will reach end of life in the Actions runner on the 15th of October 2024 :rotating_light:
Following our [change to default customers to use Node20](https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/), Node16 will reach end of life in the Actions runner on the 15th of October 2024.

From the 15th of October, we will no longer include Node16 in the Actions runner and customers will no longer be able to use Node16 Actions or operating systems that do not support Node20.

This PR updates the default runtime to [node20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), rather then node16. 

This is supported on all Actions Runners v2.308.0 or later.

Reference: https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/